### PR TITLE
Created basic implementations of GraphCreator and GraphExecutor

### DIFF
--- a/Backend/DCREngine/Business/GraphCreator.cs
+++ b/Backend/DCREngine/Business/GraphCreator.cs
@@ -1,27 +1,102 @@
 using Models;
+using System.Text.RegularExpressions;
 
 namespace Business
 {
     public class GraphCreator
     {
+        private Regex _actRegex;
+	    private Regex _relRegex;
+        
         public GraphCreator()
         {
+            // Regex (?<!-->\*)"([a-zA-Z0-9_]+!?)"(?!-->*), e.g. "ActivityA" (not followed or preceded by relation)
+            var actPattern = "(\"[a-zA-Z0-9_]+\"[!]?)";
+            _actRegex = new Regex("(?<!"+ GetRelationTypesString() +")" + actPattern + "(?!" + GetRelationTypesString() +")", RegexOptions.Compiled);
+
+            // Regex matches e.g. "ActivityA"<relationType>"ActivityB"
+            var relPattern = actPattern +"("+ GetRelationTypesString() +")"+ actPattern;
+            _relRegex = new Regex(relPattern, RegexOptions.Compiled);
 	    }
 
-        public Graph create(List<Activity> activities, List<Relation> relations)
+        public Graph Create(List<Activity> activities, List<Relation> relations)
         {
-            return new Graph(activities, relations, false);
+            return new Graph(activities, relations);
         }
 
-        public Graph create(String input)
+        public Graph Create(String input)
         {
-            return parseInput(input);
+            return ParseInput(input);
         }
 
         // TODO: Parse input (single line and multiple) to Graph instance
-        private Graph parseInput(String input)
+        private Graph ParseInput(string input)
         {
-            return new Graph();
+            var activities = ParseActivities(input);
+            var relations = ParseRelations(input, activities);
+
+            return new Graph(activities, relations);
+        }
+
+        private List<Activity> ParseActivities(string input)
+        {
+            var activities = new List<Activity>();
+            var actMatches = _actRegex.Matches(input);
+    
+            foreach (Match match in actMatches) {
+                var groups = match.Groups;
+                var activity = ParseActivity(groups[0].Value);
+                activities.Add(activity);
+            }
+            return activities;
+	    }
+
+        private List<Relation> ParseRelations(string input, List<Activity> activities)
+        {
+            var relations = new List<Relation>();
+            var relMatches = _relRegex.Matches(input);
+
+            foreach (Match match in relMatches) {
+                var groups = match.Groups;
+
+                // Get existing activities
+                var src = GetActivity(groups[1].Value, activities);
+                var trgt = GetActivity(groups[3].Value, activities);
+
+                var parsedRelationType = RelationTypeMethods.ParseStringToRelationType(groups[2].Value);
+                var relation = new Relation(parsedRelationType, src, trgt);
+                
+                // Update related activites
+                src.Relations.Add(relation);
+                trgt.Relations.Add(relation);
+                relations.Add(relation);
+            }
+            return relations;
+        }
+        
+        private Activity ParseActivity(string captured)
+        {
+            string charsToRemove = "[!()\"]";     
+            string title = Regex.Replace(captured, charsToRemove, String.Empty);
+            bool isPending = captured.Contains('!');
+            return new Activity(title, isPending);
+        }
+
+        private Activity GetActivity(string title, List<Activity> activities)
+        {
+            return activities.Single(e => e.Title == title.Replace("\"", ""));
+        }
+
+        private string GetRelationTypesString() {
+            var relationTypeList = Enum.GetValues(typeof(RelationType));
+
+            var relationStrings = new List<string>();
+            foreach (RelationType relationType in relationTypeList) {
+                var relationString = RelationTypeMethods.ParseRelationTypeToString(relationType);
+                relationStrings.Add(relationString);		
+            }
+
+            return String.Join("|", relationStrings);
         }
     }
 }

--- a/Backend/DCREngine/Business/GraphExecutor.cs
+++ b/Backend/DCREngine/Business/GraphExecutor.cs
@@ -4,9 +4,34 @@ namespace Business
 {
     public class GraphExecutor
     {
-        public Graph execute(Graph graph, String action) // TODO: Create Action/Event data model to incapsulate triggered actions/events
+        public Graph Execute(Graph graph, string activityTitle) // TODO: Create Action/Event data model to incapsulate triggered actions/events
         {
+            var activity = GetActivity(activityTitle, graph.Activities);
+
+            if (!activity.Enabled) {
+                return graph;
+            }
+
+            activity.Executed = true;
+            activity.Pending = false;
+
+            var relations = graph.Relations.Where(e => e.Target.Title == activity.Title);
+            foreach (Relation rel in relations) {
+                if (rel.Type == RelationType.EXCLUSION) {
+                    rel.Target.Included = false;
+                } else if (rel.Type == RelationType.INCLUSION) {
+                    rel.Target.Included = true;
+                } else if (rel.Type == RelationType.RESPONSE) {
+                    rel.Target.Pending = true;
+                }
+            }
+
             return graph; // TODO: Execute action/event on current graph state, return resuting graph state
+        }
+
+        private Activity GetActivity(string title, List<Activity> activities)
+        {
+            return activities.Single(e => e.Title == title);
         }
     }
 }

--- a/Backend/DCREngine/Models/Activity.cs
+++ b/Backend/DCREngine/Models/Activity.cs
@@ -34,9 +34,20 @@ namespace Models
             Relations = new List<Relation>();
         }
 
-        public void Execute() {
-            Executed = true;
-            // TODO: Propegate through Relations list
+        //TODO: Verify implementation
+        public bool Enabled 
+        {
+            get {
+                if (!this.Included) {
+                    return false;
+                }
+                foreach (Relation rel in Relations) {
+                    if (rel.Source.Title != Title && rel.Source.Included && !rel.Source.Executed) {
+                        return false;
+                    }
+                }
+                return true;
+            }
         }
     }
 }

--- a/Backend/DCREngine/Models/Graph.cs
+++ b/Backend/DCREngine/Models/Graph.cs
@@ -4,24 +4,17 @@ namespace Models
     {
         public List<Activity> Activities { get; set; }
         public List<Relation> Relations { get; set; }
-        public bool Executing { get; set; }
 
-        public Graph(List<Activity> activities, List<Relation> relations, bool executing)
+        public Graph(List<Activity> activities, List<Relation> relations)
         {
             Activities = activities;
             Relations = relations;
-            Executing = executing;
         }
 
         public Graph()
         {
             Activities = new List<Activity>();
             Relations = new List<Relation>();
-            Executing = false;
-        }
-
-        public void Execute() { //TODO: Maybe not needed
-            Executing = true;
         }
     }
 }

--- a/Backend/DCREngine/Models/Relation.cs
+++ b/Backend/DCREngine/Models/Relation.cs
@@ -17,8 +17,8 @@ namespace Models
         {
             var typ = RelationTypeMethods.ParseRelationTypeToString(Type).Replace("\\", "");
             var src = Source != null ? Source.Title : "<none>";
-            var trg = Target != null ? Target.Title : "<none>";
-            return $"{src}{typ}{trg}";
+            var trgt = Target != null ? Target.Title : "<none>";
+            return $"{src}{typ}{trgt}";
         }
     }
 }

--- a/Backend/DCREngine/Models/RelationType.cs
+++ b/Backend/DCREngine/Models/RelationType.cs
@@ -33,13 +33,15 @@ namespace Models
             switch (type)
             {
                 case RelationType.CONDITION:
-                    return "-->*";
+                    return @"-->\*";
                 case RelationType.RESPONSE:
-                    return "*-->";
+                    return @"\*-->";
                 case RelationType.EXCLUSION:
-                    return "-->%";
+                    return @"-->\%";
+                case RelationType.INCLUSION:
+                    return @"-->\+";
                 default:
-                    return "-->+";
+                    throw new NotImplementedException();
             }
         }
     }

--- a/Backend/DCREngine/Tests/GraphCreatorTests.cs
+++ b/Backend/DCREngine/Tests/GraphCreatorTests.cs
@@ -1,5 +1,6 @@
 using NUnit.Framework;
 using System;
+using System.Collections.Generic;
 using Models;
 using Business;
 
@@ -17,10 +18,40 @@ public class GraphCreatorTests
     [Test]
     public void Create_EmptyGraph()
     {
-        var graph = graphCreator.create("");
+        var graph = graphCreator.Create("");
 
         Assert.AreEqual(0, graph.Activities.Count);
         Assert.AreEqual(0, graph.Relations.Count);
-        Assert.AreEqual(false, graph.Executing);
+    }
+
+    [Test]
+    public void Create_SimpleGraph()
+    {
+        var src = new Activity("A");
+        var trgt = new Activity("B");
+        var activities = new List<Activity> {src, trgt};
+        var relations = new List<Relation> {new Relation(RelationType.CONDITION, src, trgt)};
+
+        var graph = graphCreator.Create(activities, relations);
+
+        Assert.AreEqual(2, graph.Activities.Count);
+        Assert.AreEqual(1, graph.Relations.Count);
+    }
+
+    [Test]
+    public void Parse_SimpleGraph()
+    {
+        var input = "\"ActivityA\", \"ActivityB\", \"ActivityA\"-->*\"ActivityB\"";
+
+        var graph = graphCreator.Create(input);
+
+        Assert.AreEqual(2, graph.Activities.Count);
+        Assert.AreEqual("ActivityA", graph.Activities[0].Title);
+        Assert.AreEqual("ActivityB", graph.Activities[1].Title);
+
+        Assert.AreEqual(1, graph.Relations.Count);
+        Assert.AreEqual(RelationType.CONDITION, graph.Relations[0].Type);
+        Assert.AreEqual("ActivityA", graph.Relations[0].Source.Title);
+        Assert.AreEqual("ActivityB", graph.Relations[0].Target.Title);
     }
 }


### PR DESCRIPTION
This PR includes implementations of the central functions of GraphCreator and GraphExecutor. In general, we can parse basic input strings such as "ActivityA"-->*"ActivityB"; this parses into a graph with 2 activities and 1 relation between them.

For these two components, we still need more work on execution propagation and input parsing. 

Resolves #5 
Resolves #6