### PR TITLE
Added startup-script

### DIFF
--- a/backend/DCRApi/Program.cs
+++ b/backend/DCRApi/Program.cs
@@ -1,12 +1,13 @@
 using DCR;
 
 var address = "localhost";
-var port = 4300;
+var frontendPort = 8080;
+var backendPort = 4300;
 if (args.Length == 2) {
-    address = args[0];
-    port = Convert.ToInt32(args[1]);
+    frontendPort = Convert.ToInt32(args[0]);
+    backendPort = Convert.ToInt32(args[1]);
 }
-var client = new NetworkClient(address, port);
+var client = new NetworkClient(address, backendPort);
 string[] appArgs = {$"--urls={client.ClientNode.URL}"};
 var builder = WebApplication.CreateBuilder(appArgs);
 var configuration = builder.Configuration;
@@ -21,6 +22,6 @@ var app = builder.Build();
 app.UseAuthorization();
 app.MapControllers();
 app.UseCors(
-    options => options.WithOrigins("http://localhost:8080").AllowAnyMethod().AllowAnyHeader()
+    options => options.WithOrigins($"http://{address}:{frontendPort}").AllowAnyMethod().AllowAnyHeader()
 );
 app.Run();

--- a/backend/DCRApi/Services/Miner.cs
+++ b/backend/DCRApi/Services/Miner.cs
@@ -156,7 +156,7 @@ public class Miner : BackgroundService
     // Step 3  : call ResyncLarger()
     public void ReceiveBlock(Block block) // TODO: Add sender parameter?
     {
-        throw new NotImplementedException();
+        return;
         if (block.Index <= Blockchain.GetHead().Index)
         {
             return;

--- a/frontend/src/js/axios.config.js
+++ b/frontend/src/js/axios.config.js
@@ -1,11 +1,10 @@
 import Axios from 'axios';
 
-const axios = Axios.create(
-    {
-        baseURL: 'http://localhost:4300',
-        timeout: 40000,
-        crossDomain: true
-    }
-)
+const backendPort = process.env.VUE_APP_BACKEND || '4300';
+const axios = Axios.create({
+  baseURL: `http://localhost:${backendPort}`,
+  timeout: 40000,
+  crossDomain: true
+});
 
 export default axios;

--- a/start-client.sh
+++ b/start-client.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Parse command-line arguments
+if [ $# -ne 2 ]; then
+  echo "Usage: $0 frontend-port backend-port"
+  exit 1
+fi
+FRONTEND_PORT=$1
+BACKEND_PORT=$2
+
+# Function to start the frontend server
+start_frontend() {
+  cd frontend
+  VUE_APP_BACKEND=$BACKEND_PORT npm run serve -- --port $FRONTEND_PORT &
+  cd ..
+}
+
+# Function to start the backend server
+start_backend() {
+  cd backend/DCRApi
+  dotnet run --no-build $FRONTEND_PORT $BACKEND_PORT &
+  cd ../..
+}
+
+# Function to stop the servers and perform cleanup
+stop_servers() {
+  echo "Stopping servers..."
+  pkill -P $$ # kill child processes (servers)
+  echo "Servers stopped."
+}
+
+# Start the servers
+start_frontend
+start_backend
+
+# Wait for the user to press Ctrl+C
+trap stop_servers SIGINT
+
+# Wait for child processes to finish
+wait


### PR DESCRIPTION
New script for starting a client (frontend + backend).
Usage: **./start-client.sh <frontend_port> <backend_port>**. E.g. for starting a client on frontend localhost:8080 and backend localhost:4300, run
**./start-client.sh 8080 4300**

This script does not start the DNS server or **build** the backend.